### PR TITLE
added option to change known properties at runtime

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -67,6 +67,9 @@ const config = {
   verbose: true, // Default: false
   wikibaseInstance: 'https://mywikibase.instance/w/api.php', // Default: https://www.wikidata.org/w/api.php
   userAgent: 'my-project-name/v3.2.5 (https://project.website)' // Default: `wikidata-edit/${pkg.version} (https://github.com/maxlath/wikidata-edit)`
+  customProperties: {   // Default: see /lib/properties/properties.js
+    id: { label: 'label', 'type': 'WikibaseItem' },
+  }
 }
 const wdEdit = require('wikidata-edit')(config)
 ```
@@ -90,7 +93,12 @@ It will then initialize only this function and the libs it depends on.
 
 ### Custom Wikibase instance
 
-If you use a custom Wikibase instance, additionally to passing the `wikibaseInstance` option (see above), make sure to re-fetch properties from the associated SPARQL endpoint. Otherwise, you will be stuck with [wikidata.org hard coded properties](https://github.com/maxlath/wikidata-edit/blob/ae13c6d5923edd3c092f25ee76fa141e7777aad0/lib/properties/properties.js).
+If you use a custom Wikibase instance, additionally to passing the `wikibaseInstance` option (see above), make sure that the library has access to the respective properties. There are two ways to change the used set of properties: 
+1. at runtime via config.customProperties
+2. or re-fetch the properties from the associated SPARQL endpoint.
+
+Otherwise, you will be stuck with [wikidata.org hard coded properties](https://github.com/maxlath/wikidata-edit/blob/ae13c6d5923edd3c092f25ee76fa141e7777aad0/lib/properties/properties.js).
+
 ```sh
 cd project_folder/node_modules/wikidata-edit
 # Make sure wikidata-cli is installed (especially if you installed wikidata-edit in production mode)

--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ module.exports = function (config, functionPath) {
     if (!config.password) throw new Error('missing config parameter: password')
   }
 
+  // set properties, if provided
+  if( 'customProperties' in config ) {
+    const { setProperties } = require( './lib/properties/find_datatype' );
+    setProperties( config.customProperties );
+  }
+
   if (typeof functionPath === 'string') {
     return require(`./lib/${functionPath}`)(config)
   } else {

--- a/lib/claim/find_snak.js
+++ b/lib/claim/find_snak.js
@@ -1,6 +1,6 @@
 const wdk = require('wikidata-sdk')
 const _ = require('../utils')
-const findPropertyDataType = require('../properties/find_datatype')
+const { findPropertyDataType } = require('../properties/find_datatype')
 const { parseUnit } = require('./quantity')
 const error_ = require('../error')
 

--- a/lib/claim/format_and_validate_claim_args.js
+++ b/lib/claim/format_and_validate_claim_args.js
@@ -1,5 +1,5 @@
 const validate = require('../validate')
-const findPropertyDataType = require('../properties/find_datatype')
+const { findPropertyDataType } = require('../properties/find_datatype')
 const { parseQuantity } = require('./quantity')
 const { hasSpecialSnaktype } = require('./special_snaktype')
 

--- a/lib/claim/format_claim_value.js
+++ b/lib/claim/format_claim_value.js
@@ -1,4 +1,4 @@
-const findPropertyDataType = require('../properties/find_datatype')
+const { findPropertyDataType } = require('../properties/find_datatype')
 const stringNumberPattern = /^\d+(\.\d+)?$/
 
 module.exports = (property, value) => {

--- a/lib/claim/post_snak.js
+++ b/lib/claim/post_snak.js
@@ -1,4 +1,4 @@
-const findPropertyDataType = require('../properties/find_datatype')
+const { findPropertyDataType } = require('../properties/find_datatype')
 const { singleClaimBuilders: builders } = require('./builders')
 const { hasSpecialSnaktype } = require('./special_snaktype')
 

--- a/lib/claim/snak.js
+++ b/lib/claim/snak.js
@@ -1,4 +1,4 @@
-const findPropertyDataType = require('../properties/find_datatype')
+const { findPropertyDataType } = require('../properties/find_datatype')
 const { entityEditBuilders: builders } = require('../claim/builders')
 
 module.exports = (property, value) => {

--- a/lib/entity/build_claim.js
+++ b/lib/entity/build_claim.js
@@ -1,7 +1,7 @@
 const _ = require('../utils')
 const error_ = require('../error')
 const validate = require('../validate')
-const findPropertyDataType = require('../properties/find_datatype')
+const { findPropertyDataType } = require('../properties/find_datatype')
 const { entityEditBuilders: builders } = require('../claim/builders')
 const buildSnak = require('../claim/snak')
 const { hasSpecialSnaktype } = require('../claim/special_snaktype')

--- a/lib/properties/find_datatype.js
+++ b/lib/properties/find_datatype.js
@@ -1,4 +1,4 @@
-const properties = require('./properties')
+let properties = require('./properties')
 
 const dataTypes = {
   ExternalId: 'string',
@@ -20,23 +20,26 @@ const dataTypes = {
 //   quantity)
 // - add a corresponding test and build function in lib/claim/tests.js and lib/claim/builders.js
 
-const getPropertyData = propertyId => {
+const findPropertyDataType = (propertyId) => {
   const propData = properties[propertyId]
-  if (propData) {
-    return propData
-  } else {
+  if( !propData ) {
     throw new Error(`property isn't supported yet: ${propertyId}.
-    Please request an update of proprerties at https://github.com/maxlath/wikidata-edit/issue`)
+    Please request an update of properties at https://github.com/maxlath/wikidata-edit/issue`)
   }
+  const propDataType = dataTypes[propData.type]
+  if( !propDataType ){
+      throw new Error(`datatype isn't supported yet: ${propData.type} (${propertyId} datatype).
+      Please open an issue to add support at https://github.com/maxlath/wikidata-edit/issue`)
+  }
+  return propDataType
 }
 
-module.exports = propertyId => {
-  const propData = getPropertyData(propertyId)
-  const propDataType = dataTypes[propData.type]
-  if (propDataType) {
-    return propDataType
-  } else {
-    throw new Error(`datatype isn't supported yet: ${propData.type} (${propertyId} datatype).
-    Please open an issue to add support at https://github.com/maxlath/wikidata-edit/issue`)
-  }
+
+const setProperties = (customProperties) => {
+  properties = customProperties
+}
+
+module.exports = {
+  findPropertyDataType,
+  setProperties,
 }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -2,7 +2,7 @@ const wdk = require('wikidata-sdk')
 const error_ = require('./error')
 const _ = require('./utils')
 const datatypeTests = require('./datatype_tests')
-const findPropertyDataType = require('./properties/find_datatype')
+const { findPropertyDataType } = require('./properties/find_datatype')
 const { hasSpecialSnaktype } = require('./claim/special_snaktype')
 // For a list of valid languages
 // see https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities


### PR DESCRIPTION
this adds the option to set the properties used by `wikibase-edit` within the runtime configuration instead of having to update the dependency manually.

when working with other wikibase instances I guess this makes it easier to maintain a custom set of properties without having to fiddle around in the dependencies.