### PR TITLE
Replaced bluereq by cross-fetch

### DIFF
--- a/lib/properties/fetch_properties_datatypes.js
+++ b/lib/properties/fetch_properties_datatypes.js
@@ -1,4 +1,4 @@
-const fetch = require( 'cross-fetch' )
+const fetch = require('cross-fetch')
 const error_ = require('../error')
 const propertiesByInstance = {}
 
@@ -20,7 +20,7 @@ module.exports = (config, propertyIds = []) => {
 
   const urls = wbk.getManyEntities({ ids: missingPropertyIds, props: 'info' })
 
-  return Promise.all(urls.map( (url) => fetch(url).then( (res) => res.json() ) ))
+  return Promise.all(urls.map((url) => fetch(url).then((res) => res.json())))
   .then(mergeResponsesEntities)
   .then(entities => {
     missingPropertyIds.forEach(addMissingProperty(entities, properties))

--- a/lib/properties/fetch_properties_datatypes.js
+++ b/lib/properties/fetch_properties_datatypes.js
@@ -1,4 +1,4 @@
-const breq = require('bluereq')
+const fetch = require( 'cross-fetch' )
 const error_ = require('../error')
 const propertiesByInstance = {}
 
@@ -20,7 +20,7 @@ module.exports = (config, propertyIds = []) => {
 
   const urls = wbk.getManyEntities({ ids: missingPropertyIds, props: 'info' })
 
-  return Promise.all(urls.map(url => breq.get(url)))
+  return Promise.all(urls.map( (url) => fetch(url).then( (res) => res.json() ) ))
   .then(mergeResponsesEntities)
   .then(entities => {
     missingPropertyIds.forEach(addMissingProperty(entities, properties))
@@ -30,7 +30,7 @@ module.exports = (config, propertyIds = []) => {
 const notIn = object => key => object[key] == null
 
 const mergeResponsesEntities = responses => {
-  const responsesEntities = responses.map(res => res.body.entities)
+  const responsesEntities = responses.map(res => res.entities)
   return Object.assign(...responsesEntities)
 }
 

--- a/lib/request/insistent_req.js
+++ b/lib/request/insistent_req.js
@@ -1,73 +1,46 @@
 const fetch = require('cross-fetch')
 const { delay } = require('../utils')
-const OAuth = require('oauth-1.0a')
-const CryptoJS = require('crypto-js')
 const querystring = require('querystring')
+const { getOAuthData, getSignatureHeaders } = require('./oauth')
 
 module.exports = (verb, params, autoRetry = true) => {
-  // Prepare OAuth, if set
-  var oauth
-  if (params.oauth) {
-    oauth = OAuth({
-      consumer: {
-        key: params.oauth.consumer_key,
-        secret: params.oauth.consumer_secret
-      },
-      signature_method: 'HMAC-SHA1',
-      hash_function: (baseString, key) => CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA1(baseString, key))
-    })
+  const method = verb || 'get'
+  const { url, oauth: oauthTokens, headers } = params
+  let { body } = params
+
+  var oauthData
+  if (oauthTokens) {
+    oauthData = getOAuthData(oauthTokens)
   }
 
   var attempts = 0
-  const tryRequest = () => {
-    const method = verb || 'get'
-    // collect all parameters for request
-    const reqParams = Object.assign({}, params, { method })
 
-    // OAuth
-    if (oauth) {
-      // Build signature
-      const signature = oauth.authorize({
-        url: reqParams.url,
-        method: reqParams.method,
-        // Needs body still as object for signing
-        data: Object.assign({}, reqParams.body)
-      }, {
-        secret: params.oauth.token_secret,
-        key: params.oauth.token
+  const tryRequest = async () => {
+    if (oauthData) {
+      const signatureHeaders = getSignatureHeaders({
+        url,
+        method,
+        data: body,
+        secret: oauthTokens.token_secret,
+        key: oauthTokens.token,
+        oauth: oauthData
       })
-
-      // Add to headers
-      const signatureHeaders = oauth.toHeader(signature)
-      reqParams.headers = Object.assign({}, reqParams.headers, signatureHeaders)
+      Object.assign(headers, signatureHeaders)
     }
 
-    // Serialize body, if present
-    if ((reqParams.method.toUpperCase() === 'POST') && reqParams.body) {
-      reqParams.body = querystring.stringify(params.body)
-      reqParams.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    if (method === 'post' && body != null) {
+      body = querystring.stringify(body)
+      headers['Content-Type'] = 'application/x-www-form-urlencoded'
     }
 
-    var res
-    // Run the query
-    return fetch(params.url, reqParams)
-    .then(r => {
-      // Leep a link to the response for possible error messages
-      res = r
-      return res.json()
-    })
-    .then(body => {
-      if (body.error != null) {
-        throw requestError(res, body)
-      } else {
-        return body
-      }
-    })
+    // TODO: recover request timeout
+    return fetch(url, { method, body, headers })
+    .then(parseBody)
     .catch(err => {
       if (autoRetry === false || ++attempts > 5) throw err
       if (err.name === 'maxlag' || err.name === 'TimeoutError') {
         const delaySeconds = getRetryDelay(err.headers)
-        console.warn('[wikibase-edit warn]', verb.toUpperCase(), params.url, err.message, `retrying in ${delaySeconds}s`)
+        console.warn('[wikibase-edit warn]', verb.toUpperCase(), url, err.message, `retrying in ${delaySeconds}s`)
         return delay(delaySeconds * 1000).then(tryRequest)
       } else {
         throw err
@@ -76,6 +49,14 @@ module.exports = (verb, params, autoRetry = true) => {
   }
 
   return tryRequest()
+}
+
+const parseBody = res => {
+  return res.json()
+  .then(resBody => {
+    if (resBody.error != null) throw requestError(res, resBody)
+    else return resBody
+  })
 }
 
 const requestError = function (res, body) {
@@ -90,8 +71,9 @@ const requestError = function (res, body) {
   return err
 }
 
+const defaultRetryDelay = 2
 const getRetryDelay = headers => {
   const retryAfterSeconds = headers['retry-after']
   if (/^\d+$/.test(retryAfterSeconds)) return parseInt(retryAfterSeconds)
-  else return 2
+  else return defaultRetryDelay
 }

--- a/lib/request/insistent_req.js
+++ b/lib/request/insistent_req.js
@@ -1,19 +1,23 @@
-const breq = require('bluereq')
+const fetch = require( 'cross-fetch' )
 const { delay } = require('../utils')
 
 module.exports = (verb, params, autoRetry = true) => {
+
   var attempts = 0
   const tryRequest = () => {
-    return breq[verb](params)
-    .then(res => {
-      const { body } = res
+    var res;
+    return fetch( params.url, Object.assign({}, params, { method: verb }) )
+    .then( (r) => {
+      res = r;
+      return res.json();
+    })
+    .then(body => {
       if (body.error != null) {
-        throw requestError(res, body.error)
+        throw requestError(res, body)
       } else {
         return body
       }
     })
-    .timeout(30000)
     .catch(err => {
       if (autoRetry === false || ++attempts > 5) throw err
       if (err.name === 'maxlag' || err.name === 'TimeoutError') {
@@ -29,15 +33,15 @@ module.exports = (verb, params, autoRetry = true) => {
   return tryRequest()
 }
 
-const requestError = function (res, errorData) {
-  const { code, info } = errorData
+const requestError = function (res, body) {
+  const { code, info } = body.error || {}
   const err = new Error(`${code}: ${info}`)
   err.name = code
   err.statusCode = res.statusCode
   err.statusMessage = res.statusMessage
   err.headers = res.headers
-  err.body = res.body
-  err.url = res.request.uri.href
+  err.body = body
+  err.url = res.url
   return err
 }
 

--- a/lib/request/insistent_req.js
+++ b/lib/request/insistent_req.js
@@ -1,71 +1,60 @@
-const fetch = require( 'cross-fetch' )
+const fetch = require('cross-fetch')
 const { delay } = require('../utils')
-const OAuth       = require( 'oauth-1.0a' )
-const CryptoJS    = require( 'crypto-js' )
-const querystring = require( 'querystring' )
+const OAuth = require('oauth-1.0a')
+const CryptoJS = require('crypto-js')
+const querystring = require('querystring')
 
 module.exports = (verb, params, autoRetry = true) => {
-
-  // prepare OAuth, if set
-  var oauth;
-  if( params.oauth ) {
+  // Prepare OAuth, if set
+  var oauth
+  if (params.oauth) {
     oauth = OAuth({
       consumer: {
-        key:    params.oauth.consumer_key,
-        secret: params.oauth.consumer_secret,
+        key: params.oauth.consumer_key,
+        secret: params.oauth.consumer_secret
       },
       signature_method: 'HMAC-SHA1',
-      hash_function:    (base_string, key) => CryptoJS.enc.Base64.stringify( CryptoJS.HmacSHA1( base_string, key ) )
-    });
+      hash_function: (baseString, key) => CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA1(baseString, key))
+    })
   }
 
   var attempts = 0
   const tryRequest = () => {
-    var res;
-   
+    const method = verb || 'get'
     // collect all parameters for request
-    const reqParams = Object.assign(
-      {},
-      params,
-      {
-        method: verb || 'get',
-      }
-    );
+    const reqParams = Object.assign({}, params, { method })
 
     // OAuth
-    if( oauth ) {
-
-      // build signature
-      const sig =  oauth.authorize({
-        url:    reqParams.url,
+    if (oauth) {
+      // Build signature
+      const signature = oauth.authorize({
+        url: reqParams.url,
         method: reqParams.method,
-        data:   Object.assign( {}, reqParams.body ), // needs body still as object for signing
+        // Needs body still as object for signing
+        data: Object.assign({}, reqParams.body)
       }, {
         secret: params.oauth.token_secret,
-        key: params.oauth.token 
-      });
+        key: params.oauth.token
+      })
 
-      // add to headers
-      reqParams.headers = Object.assign(
-        {} 
-        , reqParams.headers
-        , oauth.toHeader( sig )
-      );
-
+      // Add to headers
+      const signatureHeaders = oauth.toHeader(signature)
+      reqParams.headers = Object.assign({}, reqParams.headers, signatureHeaders)
     }
 
-    // serialize body, if present
-    if( (reqParams.method.toUpperCase() == 'POST') && reqParams.body ) {
-      reqParams.body = querystring.stringify( params.body );
-      reqParams.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    // Serialize body, if present
+    if ((reqParams.method.toUpperCase() === 'POST') && reqParams.body) {
+      reqParams.body = querystring.stringify(params.body)
+      reqParams.headers['Content-Type'] = 'application/x-www-form-urlencoded'
     }
 
-    // run the query
-    return fetch( params.url, reqParams )
-    .then( (r) => {
-      // keep a link to the response for possible error messages
-      res = r;
-      return res.json();
+    var res
+    // Run the query
+    return fetch(params.url, reqParams)
+    .then(r => {
+      // Leep a link to the response for possible error messages
+      res = r
+      return res.json()
     })
     .then(body => {
       if (body.error != null) {

--- a/lib/request/insistent_req.js
+++ b/lib/request/insistent_req.js
@@ -1,13 +1,69 @@
 const fetch = require( 'cross-fetch' )
 const { delay } = require('../utils')
+const OAuth       = require( 'oauth-1.0a' )
+const CryptoJS    = require( 'crypto-js' )
+const querystring = require( 'querystring' )
 
 module.exports = (verb, params, autoRetry = true) => {
+
+  // prepare OAuth, if set
+  var oauth;
+  if( params.oauth ) {
+    oauth = OAuth({
+      consumer: {
+        key:    params.oauth.consumer_key,
+        secret: params.oauth.consumer_secret,
+      },
+      signature_method: 'HMAC-SHA1',
+      hash_function:    (base_string, key) => CryptoJS.enc.Base64.stringify( CryptoJS.HmacSHA1( base_string, key ) )
+    });
+  }
 
   var attempts = 0
   const tryRequest = () => {
     var res;
-    return fetch( params.url, Object.assign({}, params, { method: verb }) )
+   
+    // collect all parameters for request
+    const reqParams = Object.assign(
+      {},
+      params,
+      {
+        method: verb || 'get',
+      }
+    );
+
+    // OAuth
+    if( oauth ) {
+
+      // build signature
+      const sig =  oauth.authorize({
+        url:    reqParams.url,
+        method: reqParams.method,
+        data:   Object.assign( {}, reqParams.body ), // needs body still as object for signing
+      }, {
+        secret: params.oauth.token_secret,
+        key: params.oauth.token 
+      });
+
+      // add to headers
+      reqParams.headers = Object.assign(
+        {} 
+        , reqParams.headers
+        , oauth.toHeader( sig )
+      );
+
+    }
+
+    // serialize body, if present
+    if( (reqParams.method.toUpperCase() == 'POST') && reqParams.body ) {
+      reqParams.body = querystring.stringify( params.body );
+      reqParams.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    }
+
+    // run the query
+    return fetch( params.url, reqParams )
     .then( (r) => {
+      // keep a link to the response for possible error messages
       res = r;
       return res.json();
     })

--- a/lib/request/oauth.js
+++ b/lib/request/oauth.js
@@ -1,0 +1,17 @@
+const OAuth = require('oauth-1.0a')
+const { enc, HmacSHA1 } = require('crypto-js')
+const hashFunction = (baseString, key) => enc.Base64.stringify(HmacSHA1(baseString, key))
+
+module.exports = {
+  getOAuthData: ({ consumer_key: key, consumer_secret: secret }) => {
+    return OAuth({
+      consumer: { key, secret },
+      signature_method: 'HMAC-SHA1',
+      hash_function: hashFunction
+    })
+  },
+  getSignatureHeaders: ({ url, method, data, secret, key, oauth }) => {
+    const signature = oauth.authorize({ url, method, data }, { key, secret })
+    return oauth.toHeader(signature)
+  }
+}

--- a/lib/request/post.js
+++ b/lib/request/post.js
@@ -51,10 +51,8 @@ const actionPost = (action, data, config) => authData => {
     headers: {
       'Cookie': cookie,
       'User-Agent': userAgent,
-      'Content-Type': 'application/x-www-form-urlencoded'
     },
-    // Formatting as form-urlencoded
-    body: querystring.stringify(data)
+    body: data,
   }
 
   return insistentReq('post', params, config.autoRetry)

--- a/lib/request/post.js
+++ b/lib/request/post.js
@@ -1,5 +1,4 @@
 const _ = require('../utils')
-const querystring = require('querystring')
 const insistentReq = require('./insistent_req')
 const throwErrorRes = require('./throw_error_res')
 const { red } = require('chalk')
@@ -50,9 +49,9 @@ const actionPost = (action, data, config) => authData => {
     oauth,
     headers: {
       'Cookie': cookie,
-      'User-Agent': userAgent,
+      'User-Agent': userAgent
     },
-    body: data,
+    body: data
   }
 
   return insistentReq('post', params, config.autoRetry)

--- a/lib/resolve_title.js
+++ b/lib/resolve_title.js
@@ -3,7 +3,7 @@
 // ex: P1 => Property:P1, Q1 => Q1 OR Item:Q1
 
 const { isEntityId } = require('wikibase-sdk')
-const fetch = require( 'cross-fetch' )
+const fetch = require('cross-fetch')
 var prefixesMapPromise
 
 module.exports = (title, instance) => {
@@ -19,9 +19,9 @@ module.exports = (title, instance) => {
 
 const getPrefixesMap = instance => {
   const infoUrl = `${instance}/w/api.php?action=query&meta=siteinfo&siprop=namespaces&format=json`
-  return fetch( infoUrl )
-    .then( (res) => res.json() )
-    .then( parsePrefixesMap )
+  return fetch(infoUrl)
+    .then((res) => res.json())
+    .then(parsePrefixesMap)
 }
 
 const parsePrefixesMap = res => {

--- a/lib/resolve_title.js
+++ b/lib/resolve_title.js
@@ -3,7 +3,7 @@
 // ex: P1 => Property:P1, Q1 => Q1 OR Item:Q1
 
 const { isEntityId } = require('wikibase-sdk')
-const { get } = require('bluereq')
+const fetch = require( 'cross-fetch' )
 var prefixesMapPromise
 
 module.exports = (title, instance) => {
@@ -19,9 +19,9 @@ module.exports = (title, instance) => {
 
 const getPrefixesMap = instance => {
   const infoUrl = `${instance}/w/api.php?action=query&meta=siteinfo&siprop=namespaces&format=json`
-  return get(infoUrl)
-  .get('body')
-  .then(parsePrefixesMap)
+  return fetch( infoUrl )
+    .then( (res) => res.json() )
+    .then( parsePrefixesMap )
 }
 
 const parsePrefixesMap = res => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,27 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@textlint/ast-node-types": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
+      "integrity": "sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==",
+      "dev": true
+    },
+    "@textlint/markdown-to-ast": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.0.9.tgz",
+      "integrity": "sha512-hfAWBvTeUGh5t5kTn2U3uP3qOSM1BSrxzl1jF3nn0ywfZXpRBZr5yRjXnl4DzIYawCtZOshmRi/tI3/x4TE1jQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^4.0.3",
+        "debug": "^2.1.3",
+        "remark-frontmatter": "^1.2.0",
+        "remark-parse": "^5.0.0",
+        "structured-source": "^3.0.2",
+        "traverse": "^0.6.6",
+        "unified": "^6.1.6"
+      }
+    },
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
@@ -176,9 +197,9 @@
       }
     },
     "bail": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
       "dev": true
     },
     "balanced-match": {
@@ -273,16 +294,10 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "ccount": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
-      "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
-      "dev": true
-    },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -290,27 +305,21 @@
       }
     },
     "character-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
-      "dev": true
-    },
-    "character-entities-html4": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
-      "integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
       "dev": true
     },
     "character-entities-legacy": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
       "dev": true
     },
     "character-reference-invalid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
       "dev": true
     },
     "circular-json": {
@@ -346,17 +355,17 @@
       "dev": true
     },
     "collapse-white-space": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-      "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+      "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -373,9 +382,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "concat-map": {
@@ -397,13 +406,12 @@
       }
     },
     "config": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-1.30.0.tgz",
-      "integrity": "sha1-HWCp81NIoTwXV5jThOgaWhbDum4=",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.31.0.tgz",
+      "integrity": "sha512-Ep/l9Rd1J9IPueztJfpbOqVzuKHQh4ZODMNt9xqTYdBBNRXbV4oTu34kCkkfdRVcDq0ohtpaeXGgb+c0LQxFRA==",
       "dev": true,
       "requires": {
-        "json5": "0.4.0",
-        "os-homedir": "1.0.2"
+        "json5": "^1.0.1"
       }
     },
     "contains-path": {
@@ -416,6 +424,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      }
     },
     "cryptiles": {
       "version": "3.1.3",
@@ -434,6 +451,11 @@
           }
         }
       }
+    },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
     },
     "d": {
       "version": "1.0.0",
@@ -524,14 +546,14 @@
       "dev": true
     },
     "doctoc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/doctoc/-/doctoc-1.3.1.tgz",
-      "integrity": "sha1-8BLjYD4xViVMLvIqyIxxkPVUJro=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/doctoc/-/doctoc-1.4.0.tgz",
+      "integrity": "sha512-8IAq3KdMkxhXCUF+xdZxdJxwuz8N2j25sMgqiu4U4JWluN9tRKMlAalxGASszQjlZaBprdD2YfXpL3VPWUD4eg==",
       "dev": true,
       "requires": {
+        "@textlint/markdown-to-ast": "~6.0.9",
         "anchor-markdown-header": "^0.5.5",
         "htmlparser2": "~3.9.2",
-        "markdown-to-ast": "~3.4.0",
         "minimist": "~1.2.0",
         "underscore": "~1.8.3",
         "update-section": "^0.3.0"
@@ -547,27 +569,33 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
           "dev": true
         }
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
@@ -605,9 +633,9 @@
       "dev": true
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
     },
     "error-ex": {
@@ -1002,6 +1030,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fault": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
+      "integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
+      "dev": true,
+      "requires": {
+        "format": "^0.2.2"
+      }
+    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -1070,6 +1107,12 @@
         "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1159,9 +1202,9 @@
       "dev": true
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "har-schema": {
@@ -1210,9 +1253,9 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
@@ -1350,15 +1393,15 @@
       "dev": true
     },
     "is-alphabetical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
       "dev": true
     },
     "is-alphanumerical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
       "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
@@ -1369,6 +1412,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-callable": {
@@ -1384,9 +1433,9 @@
       "dev": true
     },
     "is-decimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -1399,9 +1448,9 @@
       }
     },
     "is-hexadecimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
       "dev": true
     },
     "is-my-ip-valid": {
@@ -1447,6 +1496,12 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -1478,6 +1533,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-whitespace-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
+      "dev": true
+    },
+    "is-word-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -1543,10 +1610,13 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -1642,29 +1712,11 @@
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
-    "longest-streak": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
-      "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU=",
+    "markdown-escapes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
       "dev": true
-    },
-    "markdown-table": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
-      "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE=",
-      "dev": true
-    },
-    "markdown-to-ast": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-to-ast/-/markdown-to-ast-3.4.0.tgz",
-      "integrity": "sha1-Diy6gTkLBUmpFT7DsNkVthwWS+c=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.1.3",
-        "remark": "^5.0.1",
-        "structured-source": "^3.0.2",
-        "traverse": "^0.6.6"
-      }
     },
     "mime-db": {
       "version": "1.33.0",
@@ -1712,22 +1764,22 @@
       }
     },
     "mocha": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
-      "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
-        "commander": "2.11.0",
+        "commander": "2.15.1",
         "debug": "3.1.0",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
-        "growl": "1.10.3",
+        "growl": "1.10.5",
         "he": "1.1.1",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "debug": {
@@ -1740,12 +1792,12 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1774,11 +1826,21 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "oauth-1.0a": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+      "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -1869,9 +1931,9 @@
       "dev": true
     },
     "parse-entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
-      "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
@@ -2064,54 +2126,49 @@
         "resolve": "^1.1.6"
       }
     },
-    "remark": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-5.1.0.tgz",
-      "integrity": "sha1-y0Y709vLS5l5STXu4c9x16jjBow=",
+    "remark-frontmatter": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz",
+      "integrity": "sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==",
       "dev": true,
       "requires": {
-        "remark-parse": "^1.1.0",
-        "remark-stringify": "^1.1.0",
-        "unified": "^4.1.1"
+        "fault": "^1.0.1",
+        "xtend": "^4.0.1"
       }
     },
     "remark-parse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-1.1.0.tgz",
-      "integrity": "sha1-w8oQ+ajaBGFcKPCapOMEUQUm7CE=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+      "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
       "dev": true,
       "requires": {
-        "collapse-white-space": "^1.0.0",
-        "extend": "^3.0.0",
-        "parse-entities": "^1.0.2",
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
         "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
         "trim": "0.0.1",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0"
-      }
-    },
-    "remark-stringify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-1.1.0.tgz",
-      "integrity": "sha1-pxBeJbnuK/mkm3XSxCPxGwauIJI=",
-      "dev": true,
-      "requires": {
-        "ccount": "^1.0.0",
-        "extend": "^3.0.0",
-        "longest-streak": "^1.0.0",
-        "markdown-table": "^0.4.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4"
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
       "dev": true
     },
     "request": {
@@ -2231,9 +2288,9 @@
       }
     },
     "should": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
-      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "dev": true,
       "requires": {
         "should-equal": "^2.0.0",
@@ -2279,9 +2336,9 @@
       }
     },
     "should-util": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
-      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
     },
     "slice-ansi": {
@@ -2348,6 +2405,12 @@
         "pkg-conf": "^2.0.0"
       }
     },
+    "state-toggle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
+      "dev": true
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2366,18 +2429,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "stringify-entities": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
-      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
-      "dev": true,
-      "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
       }
     },
     "stringstream": {
@@ -2416,9 +2467,9 @@
       }
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
       },
@@ -2537,15 +2588,15 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-      "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
       "dev": true
     },
     "trough": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
-      "integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
       "dev": true
     },
     "tunnel-agent": {
@@ -2584,9 +2635,9 @@
       "dev": true
     },
     "unherit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
-      "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+      "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -2594,17 +2645,17 @@
       }
     },
     "unified": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-4.2.1.tgz",
-      "integrity": "sha1-dv9Dqo2kMPbn5KVchOusKtLPzS4=",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+      "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "dev": true,
       "requires": {
         "bail": "^1.0.0",
         "extend": "^3.0.0",
-        "has": "^1.0.1",
-        "once": "^1.3.3",
+        "is-plain-obj": "^1.1.0",
         "trough": "^1.0.0",
-        "vfile": "^1.0.0"
+        "vfile": "^2.0.0",
+        "x-is-string": "^0.1.0"
       }
     },
     "uniq": {
@@ -2614,27 +2665,42 @@
       "dev": true
     },
     "unist-util-is": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
-      "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
       "dev": true
     },
     "unist-util-remove-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
-      "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
     },
+    "unist-util-stringify-position": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+      "dev": true
+    },
     "unist-util-visit": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
-      "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.1.1"
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
       }
     },
     "update-section": {
@@ -2674,21 +2740,41 @@
       }
     },
     "vfile": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
-      "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c=",
-      "dev": true
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.4",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
+      }
     },
     "vfile-location": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.3.tgz",
-      "integrity": "sha512-zM5/l4lfw1CBoPx3Jimxoc5RNDAHHpk6AM6LM0pTIkm5SUSsx8ZekZ0PVdf0WEZ7kjlhSt7ZlqbRL6Cd6dBs6A==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
       "dev": true
     },
+    "vfile-message": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "dev": true,
+      "requires": {
+        "unist-util-stringify-position": "^1.1.1"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    },
     "wikibase-sdk": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.1.2.tgz",
-      "integrity": "sha512-L/NLjSaQl2qnhKagPZReWH6jrkZ+d7j1Gf/hNCZRtzwzf8AF4YqtMnRSPKfrNLs0tI8Sex7eJoiUuNwAgRgntQ=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.2.0.tgz",
+      "integrity": "sha512-5ZTSwztZeL7idC0uhuvAg2Pf/HceiK8fTEofL4BoD0wJoM4K+XZAqpLXTq3HEiHk3KhZ22wI8qV4exoqfY2erA=="
     },
     "wikibase-token": {
       "version": "3.0.4",
@@ -2719,6 +2805,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "cross-fetch": "^3.0.4",
-    "wikibase-sdk": "^7.1.6",
+    "crypto-js": "^3.1.9-1",
+    "oauth-1.0a": "^2.2.6",
+    "wikibase-sdk": "^7.2.0",
     "wikibase-token": "^3.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
   },
   "homepage": "https://github.com/maxlath/wikibase-edit",
   "dependencies": {
-    "bluereq": "^2.1.7",
-    "chalk": "^2.4.1",
-    "wikibase-sdk": "^7.1.2",
+    "chalk": "^2.4.2",
+    "cross-fetch": "^3.0.4",
+    "wikibase-sdk": "^7.1.6",
     "wikibase-token": "^3.0.4"
   },
   "devDependencies": {
-    "config": "^1.30.0",
-    "doctoc": "^1.3.1",
+    "config": "^1.31.0",
+    "doctoc": "^1.4.0",
     "git-hooks": "^1.1.10",
-    "mocha": "^5.1.1",
-    "should": "^13.2.1",
+    "mocha": "^5.2.0",
+    "should": "^13.2.3",
     "standard": "^10.0.3"
   },
   "standard": {
@@ -60,6 +60,6 @@
     ]
   },
   "engines": {
-    "node": ">= 6.4"
+    "node": ">= 7.0"
   }
 }

--- a/test/integration/alias/add.js
+++ b/test/integration/alias/add.js
@@ -35,7 +35,6 @@ describe('alias add', function () {
       console.log('aliases', aliases)
       return wbEdit.alias.add({ id, language, value: aliases })
       .then(res => {
-        console.log('res', res)
         res.success.should.equal(1)
         done()
       })

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -63,7 +63,7 @@ describe('credentials', function () {
   })
 
   // @TODO run a similar test for oauth
-  if( !('oauth' in credentials) ) {
+  if (!('oauth' in credentials)) {
     it('should re-generate credentials when re-using a pre-existing credentials object', done => {
       const wbEdit = WBEdit({ instance })
       const creds = Object.assign({}, credentials)

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -55,27 +55,29 @@ describe('credentials', function () {
   })
 
   it('should reject defining both oauth and username:password credentials', done => {
-    const { username, password } = credentials
-    const creds = { username, password, oauth: {} }
+    const creds = { username: 'abc', password: 'def', oauth: {} }
     const wbEdit = WBEdit({ instance, credentials: creds })
     wbEdit.entity.create.bind(null, params())
     .should.throw('credentials can not be both oauth tokens, and a username and password')
     done()
   })
 
-  it('should re-generate credentials when re-using a pre-existing credentials object', done => {
-    const wbEdit = WBEdit({ instance })
-    const creds = Object.assign({}, credentials)
-    wbEdit.entity.create(params(), { credentials: creds })
-    .then(() => {
-      creds.username = 'foo'
-      return wbEdit.entity.create(params(), { credentials: creds })
+  // @TODO run a similar test for oauth
+  if( !('oauth' in credentials) ) {
+    it('should re-generate credentials when re-using a pre-existing credentials object', done => {
+      const wbEdit = WBEdit({ instance })
+      const creds = Object.assign({}, credentials)
+      wbEdit.entity.create(params(), { credentials: creds })
+      .then(() => {
+        creds.username = 'foo'
+        return wbEdit.entity.create(params(), { credentials: creds })
+      })
+      .then(undesiredRes(done))
+      .catch(err => {
+        err.body.error.code.should.equal('assertuserfailed')
+        done()
+      })
+      .catch(done)
     })
-    .then(undesiredRes(done))
-    .catch(err => {
-      err.body.error.code.should.equal('assertuserfailed')
-      done()
-    })
-    .catch(done)
-  })
+  }
 })


### PR DESCRIPTION
I replaced `bluereq` by `cross-fetch` as suggested in #37 . This makes use of the `fetch` API, which is natives in (modern) browsers and just a small polyfill in node.

When `wikibase-token` also makes this change, it should cut down the indirect dependencies by about 50 entries.

In my setup, it passes all test using both OAuth and username/password credentials on node 7.0 as well as the current 13.3, so I guess everything in between should also be fine.

PS: it might be interesting to get also rid of all hard NodeJS dependencies, so one could (for whatever reason) run this directly in the browser - assuming the respective Wikibase instance has properly set up CORS headers.