### PR TITLE
Allow ommiting maxlag for interactive tasks

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -298,6 +298,8 @@ The `bot` flag will mark your edits as made by a [bot account](https://www.wikid
 ### Maxlag
 See [`maxlag` parameter documentation](https://www.mediawiki.org/wiki/Manual:Maxlag_parameter). If the Wikibase server returns a `maxlag` error, the request will automatically be re-executed after the amount of seconds recommended by the Wikibase server via the `Retry-After` header. This automatic retry can be disabled by setting `autoRetry` to `false` in the general config or the request config.
 
+As specified in the MediaWiki documentation *Interactive tasks (where a user is waiting for the result) may omit the maxlag parameter*. To do so, set `maxlag = null` in the config object.
+
 ## API
 
 All functions return promises.

--- a/lib/request/post.js
+++ b/lib/request/post.js
@@ -57,7 +57,7 @@ const actionPost = (action, data, config) => authData => {
   if (summary != null) data.summary = data.summary || summary
   if (baserevid != null) data.baserevid = data.baserevid || baserevid
   if (tags != null) data.tags = data.tags || tags.join('|')
-  data.maxlag = maxlag || 5
+  if (maxlag != null) data.maxlag = maxlag || 5
 
   params.body = data
 

--- a/lib/request/post.js
+++ b/lib/request/post.js
@@ -57,7 +57,7 @@ const actionPost = (action, data, config) => authData => {
   if (summary != null) data.summary = data.summary || summary
   if (baserevid != null) data.baserevid = data.baserevid || baserevid
   if (tags != null) data.tags = data.tags || tags.join('|')
-  if (maxlag != null) data.maxlag = maxlag || 5
+  if (maxlag !== null) data.maxlag = maxlag || 5
 
   params.body = data
 


### PR DESCRIPTION
The maxlag parameter documentation (https://www.mediawiki.org/wiki/Manual:Maxlag_parameter) specifies that "Interactive tasks (where a user is waiting for the result) may omit the maxlag parameter". Would it be OK to set `maxlag = null` in the config to omit it?