### PR TITLE
Have fetch_properties_datatypes use userAgent as well

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -190,7 +190,7 @@ wbEdit.label.set({ id, language, value }, requestConfig)
 ```
 
 Rules:
-* All parameters can either be set in `generalConfig` or `requestConfig`, except `userAgent` which can only be set in `generalConfig`
+* All parameters can either be set in `generalConfig` or `requestConfig`
 
 ### Credentials
 #### Single-user setup

--- a/lib/properties/fetch_properties_datatypes.js
+++ b/lib/properties/fetch_properties_datatypes.js
@@ -23,7 +23,8 @@ module.exports = async (config, propertyIds = []) => {
 
   const urls = WBK(instance).getManyEntities({ ids: missingPropertyIds, props: 'info' })
 
-  const responses = await Promise.all(urls.map(getJson))
+  const headers = { 'user-agent': config.userAgent }
+  const responses = await Promise.all(urls.map(url => getJson(url, { headers })))
   const responsesEntities = responses.map(parseResponse)
   const allEntities = Object.assign(...responsesEntities)
   missingPropertyIds.forEach(addMissingProperty(allEntities, properties, instance))


### PR DESCRIPTION
userAgent parameter is not used by fetch_properties_datatypes. This PR solves this.

BTW, maybe this is not the place to ask, but I thought it wasn't worth it opening another issue for this. The Readme [says](https://github.com/maxlath/wikibase-edit/blob/master/docs/how_to.md#user-content-per-request-config) that userAgent can only be set in generalConfig. However, in my code, I'm setting it in the requestConfig (because by the time I have to set the generalConfig the user agent is still undefined) and it seems to work OK. Is the Readme outdated? Or is there a reason why I shouldn't set it in the requestConfig?

Thanks!