### PR TITLE
Fix time support

### DIFF
--- a/lib/claim/get_time_object.js
+++ b/lib/claim/get_time_object.js
@@ -15,6 +15,7 @@ module.exports = value => {
     // Drop milliseconds from ISO time strings as those aren't represented in Wikibase anyway
     // ex: '2019-04-01T00:00:00.000Z' -> '2019-04-01T00:00:00Z'
     .replace('.000Z', 'Z')
+    .replace(/^\+/, '')
   if (precision == null) precision = getPrecision(time)
   const timeStringBase = getTimeStringBase(time, precision)
   return getPrecisionTimeObject(timeStringBase, precision, calendarmodel)

--- a/lib/datatype_tests.js
+++ b/lib/datatype_tests.js
@@ -35,7 +35,18 @@ module.exports = {
     if (sign === '+' && year.length <= 5) {
       try {
         time = time.replace(/^\+/, '')
-        new Date(time).toISOString()
+        let isoTime = time
+        // ISO validation would fail if either date or month are 0
+        // Replace date or date and month digits with 01
+        // if precision is less than 11 or 10, respectively
+        if (precision != null) {
+          if (precision < 10) {
+            isoTime = isoTime.replace(/^(\d{4})-\d{1,2}-\d{1,2}/, '$1-01-01')
+          } else if (precision < 11) {
+            isoTime = isoTime.replace(/^(\d{4}-\d{1,2})-\d{1,2}/, '$1-01')
+          }
+        }
+        new Date(isoTime).toISOString()
       } catch (err) {
         return false
       }

--- a/lib/entity/build_claim.js
+++ b/lib/entity/build_claim.js
@@ -41,8 +41,8 @@ const fullClaimBuilder = params => {
   if (hasSpecialSnaktype(claimData)) {
     claim = builders.specialSnaktype(property, snaktype)
   } else {
-    // In case of a rich value (monolingual text, quantity, or globe coordinate)
-    if (value == null && (claimData.text || claimData.amount || claimData.latitude)) {
+    // In case of a rich value (monolingual text, quantity, globe coordinate, or time)
+    if (value == null && (claimData.text || claimData.amount || claimData.latitude || claimData.time)) {
       value = claimData
     }
     validate.snakValue(property, datatype, value)

--- a/tests/unit/claim/time.js
+++ b/tests/unit/claim/time.js
@@ -22,6 +22,17 @@ describe('claim time', () => {
     })
   })
 
+  it('should parse explicitly positive year', () => {
+    getTimeObject('+2018').should.deepEqual({
+      time: '+2018-00-00T00:00:00Z',
+      timezone: 0,
+      before: 0,
+      after: 0,
+      precision: 9,
+      calendarmodel: 'http://www.wikidata.org/entity/Q1985727'
+    })
+  })
+
   it('should parse month without precision', () => {
     getTimeObject('2018-03').should.deepEqual({
       time: '+2018-03-00T00:00:00Z',

--- a/tests/unit/entity/edit.js
+++ b/tests/unit/entity/edit.js
@@ -219,6 +219,58 @@ describe('entity edit', () => {
     })
   })
 
+  it('should format a rich-value time claim with precision 10 or less', () => {
+    const { data } = editEntity({
+      id,
+      claims: {
+        P4: [
+          { time: '1802-02-00', precision: 10 },
+          { time: '1802-00-00', precision: 9 }
+        ]
+      }
+    })
+    JSON.parse(data.data).claims.P4.should.deepEqual([
+      {
+        rank: 'normal',
+        type: 'statement',
+        mainsnak: {
+          property: 'P4',
+          snaktype: 'value',
+          datavalue: {
+            type: 'time',
+            value: {
+              time: '+1802-02-00T00:00:00Z',
+              timezone: 0,
+              before: 0,
+              after: 0,
+              precision: 10,
+              calendarmodel: 'http://www.wikidata.org/entity/Q1985727'
+            }
+          }
+        }
+      },
+      {
+        rank: 'normal',
+        type: 'statement',
+        mainsnak: {
+          property: 'P4',
+          snaktype: 'value',
+          datavalue: {
+            type: 'time',
+            value: {
+              time: '+1802-00-00T00:00:00Z',
+              timezone: 0,
+              before: 0,
+              after: 0,
+              precision: 9,
+              calendarmodel: 'http://www.wikidata.org/entity/Q1985727'
+            }
+          }
+        }
+      }
+    ])
+  })
+
   it('should format an entity claim with a qualifier with a special snaktype', () => {
     const qualifiers = {
       P4: { snaktype: 'somevalue' }

--- a/tests/unit/entity/edit.js
+++ b/tests/unit/entity/edit.js
@@ -219,6 +219,34 @@ describe('entity edit', () => {
     })
   })
 
+  it('should format a rich-value time claim', () => {
+    const { data } = editEntity({
+      id,
+      claims: {
+        P4: [ { time: '1802-02-26', precision: 11 } ]
+      }
+    })
+    JSON.parse(data.data).claims.P4[0].should.deepEqual({
+      rank: 'normal',
+      type: 'statement',
+      mainsnak: {
+        property: 'P4',
+        snaktype: 'value',
+        datavalue: {
+          type: 'time',
+          value: {
+            time: '+1802-02-26T00:00:00Z',
+            timezone: 0,
+            before: 0,
+            after: 0,
+            precision: 11,
+            calendarmodel: 'http://www.wikidata.org/entity/Q1985727'
+          }
+        }
+      }
+    })
+  })
+
   it('should format a rich-value time claim with precision 10 or less', () => {
     const { data } = editEntity({
       id,


### PR DESCRIPTION
I think these commits fix some bugs with time values. Let me know if I should send three separate PRs.

- 3400deb: fixes [validation error](https://github.com/maxlath/wikibase-edit/blob/d42636f20da56c82a55748e3807bb4d7aea419cb/lib/validate.js#L59) because `time` was not considered as a rich value
- 26cf918: fixes getTimeStringBase [error](https://github.com/maxlath/wikibase-edit/blob/d42636f20da56c82a55748e3807bb4d7aea419cb/lib/claim/get_time_object.js#L32) for times with leading plus sign
- 431f206: ISO validation was failing with valid low-precision times such as 2021-00-00 or 2021-01-00.

BTW, regarding 431f206, you [write](https://github.com/maxlath/wikibase-edit/blob/d42636f20da56c82a55748e3807bb4d7aea419cb/lib/datatype_tests.js#L31) "Only trying to parse 5-digit years or below". Shouldn't 5-digit years fail? Shouldn't that be 4-digits only?